### PR TITLE
References to the Develocity Build Validation Scripts repository are renamed

### DIFF
--- a/.github/workflows/cron-shared-action.yml
+++ b/.github/workflows/cron-shared-action.yml
@@ -14,12 +14,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download the validation scripts
-        uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/maven/download@v2.5.1
+        uses: gradle/develocity-build-validation-scripts/.github/actions/maven/download@v2.5.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Build Validation Scripts
-        uses: gradle/gradle-enterprise-build-validation-scripts/.github/actions/maven/experiment-2@v2.5.1
+        uses: gradle/develocity-build-validation-scripts/.github/actions/maven/experiment-2@v2.5.1
         with:
           gitRepo: $(pwd)
           goals: verify

--- a/.github/workflows/cron-shell-script.yml
+++ b/.github/workflows/cron-shell-script.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Download Build Validation Scripts
         run: |
           # Download scripts zip
-          curl -s -L -O https://github.com/gradle/gradle-enterprise-build-validation-scripts/releases/download/v${script_version}/gradle-enterprise-maven-build-validation-${script_version}.zip
+          curl -s -L -O https://github.com/gradle/develocity-build-validation-scripts/releases/download/v${script_version}/gradle-enterprise-maven-build-validation-${script_version}.zip
           # Verify zip
           echo "${script_checksum}  gradle-enterprise-maven-build-validation-${script_version}.zip" | shasum -a 512 -c-
           # Extract Build Validation Scripts

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Run the following command and follow the instructions in your terminal:
     ```shell
     version="2.5.1"
     # You can find the SHA 512 checksum on the releases page:
-    # https://github.com/gradle/gradle-enterprise-build-validation-scripts/releases
+    # https://github.com/gradle/develocity-build-validation-scripts/releases
     checksum="131fb1a0de2409d7f1747bd0da75680e757d791596a81f43787f36badf40f1385aa593ab053c1b396a1bcbf6b9da64cc355e78c04eb55ff5d0a6526a5f318e54"
     ```
 
@@ -60,7 +60,7 @@ Run the following command and follow the instructions in your terminal:
     # Download and extract in temp directory
     pushd /tmp
     # Download scripts zip
-    curl -s -L -O "https://github.com/gradle/gradle-enterprise-build-validation-scripts/releases/download/v${version}/gradle-enterprise-maven-build-validation-${version}.zip"
+    curl -s -L -O "https://github.com/gradle/develocity-build-validation-scripts/releases/download/v${version}/gradle-enterprise-maven-build-validation-${version}.zip"
     # Verify zip
     echo "${checksum}  gradle-enterprise-maven-build-validation-${version}.zip" | shasum -a 512 -c-
     # Extract Build Validation Scripts
@@ -109,4 +109,4 @@ Be sure to check out our other **free** [courses][dpe-university] and [labs](htt
 [dpe-university]: https://dpeuniversity.gradle.com/
 [develocity-url]: https://dpeuniversity-develocity.gradle.com/
 [build-cache-course]: https://dpeuniversity.gradle.com/c/47262fea1e74b719afb590d8cb3f8280bf2af732
-[build-validation-scripts]: https://github.com/gradle/gradle-enterprise-build-validation-scripts
+[build-validation-scripts]: https://github.com/gradle/develocity-build-validation-scripts


### PR DESCRIPTION
> [!CAUTION]
> This PR is not to be merged until the renaming has taken place. This is currently scheduled to happen on Dec 17 during EMEA morning. Check https://github.com/gradle/develocity-build-validation-scripts to verify the current state.

This PR renames references to the old Develocity Build Validation Scripts repository name to https://github.com/gradle/develocity-build-validation-scripts